### PR TITLE
Separated Pytorch class - FastAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ data/*
 /.pytest_cache
 /MLFLOW_TRACKING_URI
 /zxczx
+BeansKey.pem
+src/data/dataloaders/test_loader.pt
+src/data/dataloaders/train_loader.pt
+src/data/dataloaders/validation_loader.pt

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,4 +6,4 @@ load_dotenv()
 
 ROOT_DIR = Path(Path(__file__).resolve().parent)
 
-MODELS_DIR = ROOT_DIR / "models"
+MODELS_DIR = ROOT_DIR / "../models"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+ROOT_DIR = Path(Path(__file__).resolve().parent)
+
+MODELS_DIR = ROOT_DIR / "models"

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -1,22 +1,15 @@
-from datetime import datetime
-from functools import wraps
 from http import HTTPStatus
 from typing import List
-
+from PIL import Image
+from io import BytesIO
 import uvicorn
-from fastapi import FastAPI, Request, status
-from fastapi.logger import logger
-from fastapi.encoders import jsonable_encoder
-from fastapi.responses import RedirectResponse, JSONResponse
-from fastapi.exceptions import RequestValidationError
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-
+from fastapi import FastAPI, Request, File, UploadFile, HTTPException
+from torchvision import transforms
 import torch
-from .. import MODELS_DIR
-from ..models.model import SimpleCNNReducedStride10 
+from src import MODELS_DIR
+from src.models.model import SimpleCNNReducedStride10
+from pydantic import BaseModel, ValidationError
 
-from pydantic import BaseModel
 
 model_wrappers_list: List[dict] = []
 
@@ -27,35 +20,15 @@ app = FastAPI(
     version="0.1",
 )
 
-def construct_response(f):
-    """Construct a JSON response for an endpoint's results."""
-
-    @wraps(f)
-    def wrap(request: Request, *args, **kwargs):
-        results = f(request, *args, **kwargs)
-
-        # Construct response
-        response = {
-            "message": results["message"],
-            "MODELS_DIR": results["MODELS_DIR"],
-            "model":results["model"],
-            "method": request.method,
-            "status-code": results["status-code"],
-            "timestamp": datetime.now().isoformat(),
-            "url": request.url._url,
-        }
-
-        # Add data
-        if "data" in results:
-            response["data"] = results["data"]
-
-        return response
-
-    return wrap
+class BeansImageInfo(BaseModel):
+    filename: str
+    content_type: str
+    width: int
+    height: int
 
 
 @app.on_event("startup")
-def _load_models():
+def _load_models_and_constants():
 
     # Initialize the pytorch model
     model=SimpleCNNReducedStride10()
@@ -70,15 +43,23 @@ def _load_models():
         with open(path, "rb") as file:
             model.load_state_dict(torch.load(file))
             model.eval()
-    
+
+    predict_dict = {
+        0: "angular_leaf_spot",
+        1: "bean_rust",
+        2: "healthy"
+    }
+
+    allowed_content_types = ["image/jpeg", "image/jpg", "image/png"]
+
     # add model and other preprocess tools too app state
     app.package = {
-        #"scaler": load(CONFIG['SCALAR_PATH']),  # joblib.load
-        "model": model
+        "model": model,
+        "pred_dict": predict_dict,
+        'allowed_content_types': allowed_content_types
     }
 
 @app.get("/", tags=["General"])  # path operation decorator
-@construct_response
 def _index(request: Request):
     """Root endpoint."""
 
@@ -87,11 +68,101 @@ def _index(request: Request):
         "status-code": HTTPStatus.OK,
         "data": {"message": "Welcome to Teams Beans classifier! Please, read the `/docs`!"},
         "MODELS_DIR":{"MODELS_DIR":MODELS_DIR},
-        "model":{"model":app.package},
+        "model":{"model":app.package['model']},
     }
     return response
 
 
 
-# @app.get("/models", tags=["Prediction"])
-# @construct_response
+# curl -X POST -H "Content-Type: multipart/form-data" -H "Accept: application/json"
+# -F "beans_img=@/Users/wwoszczek/Desktop/test_beans_img/0.jpg"
+# http://localhost:8000/make_prediction
+
+# API call only for 500x500 pictures
+@app.post("/make_prediction_strict", tags=["Prediction"])
+async def _index(beans_img: UploadFile = File(...)):
+    try:
+        img_info = BeansImageInfo(
+            filename=beans_img.filename,
+            content_type=beans_img.content_type,
+            width=0,
+            height=0)
+
+        if img_info.content_type not in app.package['allowed_content_types']:
+            raise HTTPException(status_code=415, detail="Unsupported media type. Please upload JPG or PNG file.")
+
+        img_bytes = await beans_img.read()
+        img_raw = Image.open(BytesIO(img_bytes)).convert('RGB')
+        img_info.width, img_info.height = img_raw.size
+
+    except ValidationError as e:
+        raise HTTPException(status_code=415, detail=f"Invalid request: {e}")
+
+
+    if img_info.height != 500 or img_info.width != 500:
+        raise HTTPException(status_code=400, detail="Image dimensions are not equal to 500x500. "
+                                                    "Please upload appropriate file.")
+
+    model = app.package['model']
+
+    preprocess = transforms.Compose([
+        transforms.ToTensor(),  # Convert PIL Image to PyTorch tensor
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),  # Normalize RGB channels
+    ])
+
+    image = preprocess(img_raw).unsqueeze(0)
+
+    output = torch.exp(model(image))
+
+    pred = torch.argmax(output, 1).item()
+    label = app.package['pred_dict'][pred]
+
+    return {
+        "probs": output.tolist(),
+        "prediction": label
+    }
+
+# API calls for images of any size
+@app.post("/make_prediction", tags=["Prediction"])
+async def _index(beans_img: UploadFile = File(...)):
+    try:
+        img_info = BeansImageInfo(
+            filename=beans_img.filename,
+            content_type=beans_img.content_type,
+            width=0,
+            height=0)
+
+        if img_info.content_type not in app.package['allowed_content_types']:
+            raise HTTPException(status_code=415, detail="Unsupported media type. Please upload JPG or PNG file.")
+
+        img_bytes = await beans_img.read()
+        img_raw = Image.open(BytesIO(img_bytes)).convert('RGB')
+        img_info.width, img_info.height = img_raw.size
+
+    except ValidationError as e:
+        raise HTTPException(status_code=415, detail=f"Invalid request: {e}")
+
+
+    model = app.package['model']
+
+    preprocess = transforms.Compose([
+        transforms.Resize((500, 500)),
+        transforms.ToTensor(),  # Convert PIL Image to PyTorch tensor
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),  # Normalize RGB channels
+    ])
+
+    image = preprocess(img_raw).unsqueeze(0)
+
+    output = torch.exp(model(image))
+
+    pred = torch.argmax(output, 1).item()
+    label = app.package['pred_dict'][pred]
+
+    return {
+        "probs": output.tolist(),
+        "prediction": label
+    }
+
+
+
+

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from functools import wraps
+from http import HTTPStatus
+from typing import List
+
+import uvicorn
+from fastapi import FastAPI, Request, status
+from fastapi.logger import logger
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import RedirectResponse, JSONResponse
+from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+
+import torch
+from .. import MODELS_DIR
+from ..models.model import SimpleCNNReducedStride10 
+
+from pydantic import BaseModel
+
+model_wrappers_list: List[dict] = []
+
+# Define application
+app = FastAPI(
+    title="Team Beans",
+    description="This API let you make predictions on beans pics.",
+    version="0.1",
+)
+
+def construct_response(f):
+    """Construct a JSON response for an endpoint's results."""
+
+    @wraps(f)
+    def wrap(request: Request, *args, **kwargs):
+        results = f(request, *args, **kwargs)
+
+        # Construct response
+        response = {
+            "message": results["message"],
+            "MODELS_DIR": results["MODELS_DIR"],
+            "model":results["model"],
+            "method": request.method,
+            "status-code": results["status-code"],
+            "timestamp": datetime.now().isoformat(),
+            "url": request.url._url,
+        }
+
+        # Add data
+        if "data" in results:
+            response["data"] = results["data"]
+
+        return response
+
+    return wrap
+
+
+@app.on_event("startup")
+def _load_models():
+
+    # Initialize the pytorch model
+    model=SimpleCNNReducedStride10()
+
+    model_paths = [
+        filename
+        for filename in MODELS_DIR.iterdir()
+        if filename.suffix == ".pt" and filename.stem.startswith("trained_model")
+    ]
+
+    for path in model_paths:
+        with open(path, "rb") as file:
+            model.load_state_dict(torch.load(file))
+            model.eval()
+    
+    # add model and other preprocess tools too app state
+    app.package = {
+        #"scaler": load(CONFIG['SCALAR_PATH']),  # joblib.load
+        "model": model
+    }
+
+@app.get("/", tags=["General"])  # path operation decorator
+@construct_response
+def _index(request: Request):
+    """Root endpoint."""
+
+    response = {
+        "message": HTTPStatus.OK.phrase,
+        "status-code": HTTPStatus.OK,
+        "data": {"message": "Welcome to Teams Beans classifier! Please, read the `/docs`!"},
+        "MODELS_DIR":{"MODELS_DIR":MODELS_DIR},
+        "model":{"model":app.package},
+    }
+    return response
+
+
+
+# @app.get("/models", tags=["Prediction"])
+# @construct_response

--- a/src/data/load_data.py
+++ b/src/data/load_data.py
@@ -10,7 +10,7 @@ def main():
 
     current_directory = os.getcwd()
 
-    raw_directory = os.path.join(current_directory, "raw")
+    raw_directory = os.path.join(current_directory, "../../data/raw")
 
     # Save the dataset to the specified local directory
     dataset.save_to_disk(raw_directory)

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -56,11 +56,11 @@ def main():
     
     current_directory = os.getcwd()
 
-    dataset_train = DatasetMain.from_file(os.path.join(current_directory, "raw/train/") + "data-00000-of-00001.arrow")
+    dataset_train = DatasetMain.from_file(os.path.join(current_directory, "../../data/raw/train/") + "data-00000-of-00001.arrow")
 
-    dataset_validation = DatasetMain.from_file(os.path.join(current_directory, "raw/validation/") + "data-00000-of-00001.arrow")
+    dataset_validation = DatasetMain.from_file(os.path.join(current_directory, "../../data/raw/validation/") + "data-00000-of-00001.arrow")
 
-    dataset_test = DatasetMain.from_file(os.path.join(current_directory, "raw/test/") + "data-00000-of-00001.arrow")
+    dataset_test = DatasetMain.from_file(os.path.join(current_directory, "../../data/raw/test/") + "data-00000-of-00001.arrow")
 
     custom_train = CustomDataset(dataset_train)
     custom_validation = CustomDataset(dataset_validation)
@@ -72,13 +72,13 @@ def main():
     test_loader = DataLoader(custom_test, batch_size=32, shuffle=False)
     
     # Create the directory if it doesn't exist
-    if not os.path.exists('dataloaders'):
-        os.makedirs('dataloaders')
+    if not os.path.exists('../../data/processed'):
+        os.makedirs('../../data/processed')
 
     # Save the DataLoader to a file
-    torch.save(train_loader, 'dataloaders/train_loader.pt')
-    torch.save(validation_loader, 'dataloaders/validation_loader.pt')
-    torch.save(test_loader, 'dataloaders/test_loader.pt')
+    torch.save(train_loader, '../../data/processed/train_loader.pt')
+    torch.save(validation_loader, '../../data/processed/validation_loader.pt')
+    torch.save(test_loader, '../../data/processed/test_loader.pt')
     
     
     

--- a/src/data/toDF_imgMetadata.py
+++ b/src/data/toDF_imgMetadata.py
@@ -41,13 +41,11 @@ def add_image_metadata(df):
 def main():
     script_dir = os.path.dirname(os.path.realpath(__file__))
 
-    raw_directory = os.path.join(script_dir, "raw")
+    raw_directory = os.path.join(script_dir, "../../data/raw")
     dataset = load_from_disk(raw_directory)
 
     train_data = dataset["train"]
-
     test_data = dataset["test"]
-
     validation_data = dataset["validation"]
 
     train_df = train_data.to_pandas()

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -1,0 +1,52 @@
+import torch
+import torch.nn.functional as F
+import torch.nn as nn
+
+class SimpleCNNReducedStride10(nn.Module):
+    """
+    This is the architecture of our CNN.
+    """
+    def __init__(self, num_classes=3):
+        super(SimpleCNNReducedStride10, self).__init__()
+        self.conv1 = nn.Conv2d(in_channels=3, out_channels=8, kernel_size=3, stride=2, padding=1)
+        self.relu1 = nn.ReLU()
+        
+        self.conv2 = nn.Conv2d(in_channels=8, out_channels=16, kernel_size=3, stride=2, padding=1)
+        self.relu2 = nn.ReLU()
+        
+        self.dropout = nn.Dropout(0.5)  # Add dropout for regularization
+        
+        # Calculate the correct input size for fc1 based on the spatial dimensions
+        self.fc1_input_size = self.calculate_fc1_input_size()
+        self.fc1 = nn.Linear(250000, 256)
+        self.relu3 = nn.ReLU()
+        
+        self.dropout2 = nn.Dropout(0.5)  # Add dropout for regularization
+        
+        self.fc2 = nn.Linear(256, num_classes)
+        self.log_softmax = nn.LogSoftmax(dim=1)  # Softmax activation for classification
+
+    def calculate_fc1_input_size(self):
+        # Assuming the output size after the second convolutional layer
+        # with stride 10 is (16, 50, 50), calculate the input size for fc1
+        return 16 * 50 * 50
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.relu1(x)
+        
+        x = self.conv2(x)
+        x = self.relu2(x)
+        
+        x = x.view(x.size(0), -1)  # Flatten the feature maps
+        x = self.dropout(x)  # Apply dropout for regularization
+        
+        x = self.fc1(x)
+        
+        x = self.relu3(x)
+        x = self.dropout2(x)
+        
+        x = self.fc2(x)
+        
+        x = self.log_softmax(x)  # Apply softmax for classification
+        return x

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -49,9 +49,9 @@ def main():
     print(os.path.join(project_root,'.env'))
     load_dotenv(dotenv_path=os.path.join(project_root,'.env'))
 
-    train_loader = torch.load(os.path.join(project_root,'src', 'data', 'dataloaders', 'train_loader.pt'))
-    validation_loader= torch.load(os.path.join(project_root, 'src','data', 'dataloaders', 'validation_loader.pt'))
-    test_loader = torch.load(os.path.join(project_root, 'src','data', 'dataloaders', 'test_loader.pt'))
+    train_loader = torch.load(os.path.join(project_root, 'data', 'processed', 'train_loader.pt'))
+    validation_loader= torch.load(os.path.join(project_root,'data', 'processed', 'validation_loader.pt'))
+    test_loader = torch.load(os.path.join(project_root,'data', 'processed', 'test_loader.pt'))
 
     # Set MLFLOW_TRACKING_USERNAME and MLFLOW_TRACKING_PASSWORD
     mlflow_tracking_username = os.getenv('MLFLOW_TRACKING_USERNAME')
@@ -183,7 +183,7 @@ def main():
                     
     
     # save the trained model
-    torch.save(model.state_dict(), 'trained_model.pt')
+    torch.save(model.state_dict(), '../../models/trained_model.pt')
             
     # fetch the auto logged parameters and metrics
     print_auto_logged_info(mlflow.get_run(run_id=run.info.run_id))

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 import torch.nn as nn
 from codecarbon import EmissionsTracker
 from torchvision import transforms
+from model import SimpleCNNReducedStride10
 
 class CustomDataset(Dataset):
     """
@@ -32,58 +33,6 @@ class CustomDataset(Dataset):
 
         return image, label
     
-
-class SimpleCNNReducedStride10(nn.Module):
-    """
-    This is the architecture of our CNN.
-    """
-    def __init__(self, num_classes=3):
-        super(SimpleCNNReducedStride10, self).__init__()
-        self.conv1 = nn.Conv2d(in_channels=3, out_channels=8, kernel_size=3, stride=2, padding=1)
-        self.relu1 = nn.ReLU()
-        
-        self.conv2 = nn.Conv2d(in_channels=8, out_channels=16, kernel_size=3, stride=2, padding=1)
-        self.relu2 = nn.ReLU()
-        
-        self.dropout = nn.Dropout(0.5)  # Add dropout for regularization
-        
-        # Calculate the correct input size for fc1 based on the spatial dimensions
-        self.fc1_input_size = self.calculate_fc1_input_size()
-        self.fc1 = nn.Linear(250000, 256)
-        self.relu3 = nn.ReLU()
-        
-        self.dropout2 = nn.Dropout(0.5)  # Add dropout for regularization
-        
-        self.fc2 = nn.Linear(256, num_classes)
-        self.log_softmax = nn.LogSoftmax(dim=1)  # Softmax activation for classification
-
-    def calculate_fc1_input_size(self):
-        # Assuming the output size after the second convolutional layer
-        # with stride 10 is (16, 50, 50), calculate the input size for fc1
-        return 16 * 50 * 50
-
-    def forward(self, x):
-        x = self.conv1(x)
-        x = self.relu1(x)
-        
-        x = self.conv2(x)
-        x = self.relu2(x)
-        
-        x = x.view(x.size(0), -1)  # Flatten the feature maps
-        x = self.dropout(x)  # Apply dropout for regularization
-        
-        x = self.fc1(x)
-        
-        x = self.relu3(x)
-        x = self.dropout2(x)
-        
-        x = self.fc2(x)
-        
-        x = self.log_softmax(x)  # Apply softmax for classification
-        return x
-    
-
-
 def print_auto_logged_info(r):
     tags = {k: v for k, v in r.data.tags.items() if not k.startswith("mlflow.")}
     artifacts = [f.path for f in MlflowClient().list_artifacts(r.info.run_id, "model")]
@@ -130,10 +79,7 @@ def main():
         tracker.start()
         
     with mlflow.start_run() as run:
-        ## The idea is to get the autolog to run for our pytorch funct. 
-        ## It might depend on the funct. we choose and the pytorch version
-        ## Thus initially I defined some metrics to try it.
-        
+                
         # Create an instance of the SimpleCNNReduced model
         model = SimpleCNNReducedStride10(num_classes=3)
 
@@ -237,7 +183,7 @@ def main():
                     
     
     # save the trained model
-    torch.save(model, 'trained_model.pt')
+    torch.save(model.state_dict(), 'trained_model.pt')
             
     # fetch the auto logged parameters and metrics
     print_auto_logged_info(mlflow.get_run(run_id=run.info.run_id))


### PR DESCRIPTION
- API call for all image sizes (picture is transformed to 500x500 inside)
- API call only for 500x500 images (other sizes raise BadRequest Error)
- cleaning up paths so that it was more consistent with cookiecutter template guidelines (in src directory only code)

to test API calls:

curl -X POST -H "Content-Type: multipart/form-data" -H "Accept: application/json" -F "beans_img=@path/to/image.jpg"  http://localhost:8000/make_prediction